### PR TITLE
Added suggestion support, and suggestion for using UNLINK instead of DEL

### DIFF
--- a/lib/safer_redis/command_doc.rb
+++ b/lib/safer_redis/command_doc.rb
@@ -52,6 +52,10 @@ module SaferRedis
       command.fetch("complexity", nil)
     end
 
+    def suggestion
+      Suggestion.for_command(name)
+    end
+
     private
 
     def command

--- a/lib/safer_redis/danger.rb
+++ b/lib/safer_redis/danger.rb
@@ -15,6 +15,13 @@ module SaferRedis
         If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
       MESSAGE
 
+      unless doc.suggestion.nil?
+        message = <<~MESSAGE
+          #{message}
+          Suggestion: #{doc.suggestion.description}
+        MESSAGE
+      end
+
       super(message)
     end
   end

--- a/lib/safer_redis/danger.rb
+++ b/lib/safer_redis/danger.rb
@@ -15,7 +15,7 @@ module SaferRedis
         If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
       MESSAGE
 
-      unless doc.suggestion.nil?
+      if doc.suggestion
         message = <<~MESSAGE
           #{message}
           Suggestion: #{doc.suggestion.description}

--- a/lib/safer_redis/suggestion.rb
+++ b/lib/safer_redis/suggestion.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SaferRedis
+  class Suggestion
+    attr_reader :command, :description
+
+    def initialize(command, description)
+      @command = command
+      @description = description
+    end
+
+    def self.for_command(command)
+      case command
+      when "DEL"
+        new(command, "Consider using the non-blocking UNLINK command instead to delete the key on a background thread")
+      else
+        nil
+      end
+    end
+  end
+end

--- a/spec/safer_redis_spec.rb
+++ b/spec/safer_redis_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe SaferRedis do
         Complexity: O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).
 
         If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
+
+        Suggestion: Consider using the non-blocking UNLINK command instead to delete the key on a background thread
+      MESSAGE
+    end
+
+    it "raises Danger for KEYS because it's @dangerous and @slow" do
+      expect {
+        SaferRedis.assess!(SaferRedis::CommandDoc.new("KEYS"))
+      }.to raise_error(SaferRedis::Danger, <<~MESSAGE)
+        The KEYS Redis command might be dangerous.
+
+        https://redis.io/commands/keys/
+
+        ACL categories: @keyspace @read @slow @dangerous
+
+        Complexity: O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.
+
+        If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
       MESSAGE
     end
 

--- a/spec/suggestion_spec.rb
+++ b/spec/suggestion_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe SaferRedis::Suggestion do
+  describe ".for_command" do
+    it "has a suggestion for DEL" do
+      suggestion = SaferRedis::Suggestion.for_command("DEL")
+
+      expect(suggestion.description).to eq "Consider using the non-blocking UNLINK command instead to delete the key on a background thread"
+    end
+
+    it "has no suggestion for KEYS" do
+      expect(SaferRedis::Suggestion.for_command("KEYS")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
After doing some research, I found that using the [UNLINK](https://redis.io/commands/unlink/) command instead of DEL is safer for deleting big keys as it does the delete in a background thread.

This PR adds some basic plumbing for adding suggestions to the error messages, and adds one in for DEL.

We could potentially add more for things like KEYS => SCAN etc down the track or other slow commands.