### PR TITLE
Allow @slow commands if they're O(1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    safer_redis (0.1.0)
+    safer_redis (1.0.0)
       redis (>= 4.6.0)
       zeitwerk
 
@@ -11,9 +11,9 @@ GEM
     connection_pool (2.3.0)
     diff-lcs (1.5.0)
     rake (13.0.6)
-    redis (5.0.5)
+    redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.11.2)
+    redis-client (0.12.1)
       connection_pool
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -32,6 +32,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   rake (~> 13.0)

--- a/lib/safer_redis.rb
+++ b/lib/safer_redis.rb
@@ -28,7 +28,13 @@ module SaferRedis
   end
 
   def self.assess!(doc)
-    if doc.dangerous? || doc.slow?
+    if doc.dangerous?
+      # Anything tagged @dangerous is… dangerous
+      raise SaferRedis::Danger.new(doc)
+
+    elsif doc.slow? && doc.complexity != "O(1)"
+      # Anything tagged @slow might be dangerous, but we'll let through O(1)
+      # complexity commands e.g. SET
       raise SaferRedis::Danger.new(doc)
     end
   end

--- a/spec/interceptor_spec.rb
+++ b/spec/interceptor_spec.rb
@@ -5,6 +5,10 @@ require "redis"
 RSpec.describe SaferRedis::Interceptor do
 
   class FakeRedis
+    def set(*keys)
+      send_command([:set] + keys)
+    end
+
     def del(*keys)
       send_command([:del] + keys)
     end
@@ -32,6 +36,10 @@ RSpec.describe SaferRedis::Interceptor do
     expect {
       redis.del("hello")
     }.to raise_error(SaferRedis::Danger, /The DEL Redis command might be dangerous.*@slow.*O\(N\)/m)
+  end
+
+  it "lets through a @slow (but not @dangerous) command if it's O(1) e.g. SET" do
+    redis.set("hello", "world")
   end
 
   it "can really run a slow command" do

--- a/spec/safer_redis_spec.rb
+++ b/spec/safer_redis_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe SaferRedis do
         SaferRedis.assess!(SaferRedis::CommandDoc.new("TYPE"))
       }.to_not raise_error
     end
+
+    it "raises no error for SET because despite being @slow it's only O(1)" do
+      expect {
+        SaferRedis.assess!(SaferRedis::CommandDoc.new("SET"))
+      }.to_not raise_error
+    end
   end
 
   it "has a version number" do


### PR DESCRIPTION
This pull request teaches SaferRedis to allow commands tagged `@slow` as long as they're only `O(1)` complexity.

From #3:

> SaferRedis is a bit twitchy, and risks warning-fatigue.
> For example a simple `SET` command:
> 
> ```
> The SET Redis command might be dangerous. (SaferRedis::Danger)
> 
> https://redis.io/commands/set/
> 
> ACL categories: @write @string @slow
> 
> Complexity: O(1)
> 
> If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
> ```
> 
> That triggered because [the SET docs](https://redis.io/commands/set/) say it's `@slow`.
> 
> I think we should ignore `@slow` when it's `O(1)`, but continue to alert for e.g. `O(N)` e.g. https://redis.io/commands/del/

Resolves #3