### PR TITLE
Treat `DEL` as `UNLINK` if `lazyfree-lazy-user-del` is set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,39 @@
 PATH
   remote: .
   specs:
-    safer_redis (1.0.0)
+    safer_redis (1.1.0)
       redis (>= 4.6.0)
       zeitwerk
 
 GEM
   remote: https://rubygems.org/
   specs:
-    connection_pool (2.3.0)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    rake (13.0.6)
-    redis (5.0.6)
-      redis-client (>= 0.9.0)
-    redis-client (0.12.1)
+    rake (13.1.0)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
+    redis-client (0.18.0)
       connection_pool
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
-    zeitwerk (2.6.6)
+    rspec-support (3.12.1)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
 
 DEPENDENCIES
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ SaferRedis wraps a Redis connection, and warns you before letting through comman
 
 Inspiration is taken from https://github.com/ankane/strong_migrations which provides similar guard-rails for potentially dangerous database migrations.
 
+## Special cases
+
+Commands tagged as `@slow` but with only O(1) complexity are not considered dangerous. This includes
+e.g. the extremely commonly used `SET` command.
+
+The [`DEL`](https://redis.io/commands/del/) command (`@slow`) is treated as [`UNLINK`](https://redis.io/commands/unlink/) (`@fast`) when the `lazyfree-lazy-user-del` server option is set.
+
 ## Limitations
 
-Currently SaferRedis works with the [`redis` gem](https://rubygems.org/gems/redis) from https://github.com/redis/redis-rb (regardless of which connection adapter is being used, e.g. [`hiredis`](https://rubygems.org/gems/hiredis)) by hooking into the private `#send_command` method which was introduced in v4.6.0. This isn't a stable API, so other interception strategies will be considered and may be added in future. Some Redis connectors/drivers suport middleware, but others don't.
+Currently SaferRedis works with the [`redis` gem](https://rubygems.org/gems/redis) from https://github.com/redis/redis-rb (regardless of which connection adapter is being used, e.g. [`hiredis`](https://rubygems.org/gems/hiredis)) by hooking into the private `#send_command` method which was introduced in v4.6.0. This isn't a stable API, so other interception strategies will be considered and may be added in future. Some Redis connectors/drivers support middleware, but others don't.
 
 Some commands are documented at the subcommand level as multiple words (e.g. `CLIENT LIST`). SaferRedis currently only recognises commands documented at their top-level single word (e.g. `DEL`). Support for multi-word commands will be considered and may be added in future.
 

--- a/lib/safer_redis.rb
+++ b/lib/safer_redis.rb
@@ -26,16 +26,4 @@ module SaferRedis
   ensure
     @active = was
   end
-
-  def self.assess!(doc)
-    if doc.dangerous?
-      # Anything tagged @dangerous is… dangerous
-      raise SaferRedis::Danger.new(doc)
-
-    elsif doc.slow? && doc.complexity != "O(1)"
-      # Anything tagged @slow might be dangerous, but we'll let through O(1)
-      # complexity commands e.g. SET
-      raise SaferRedis::Danger.new(doc)
-    end
-  end
 end

--- a/lib/safer_redis/assessor.rb
+++ b/lib/safer_redis/assessor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "json"
+
+module SaferRedis
+  class Assessor
+    def self.assess!(doc, redis:)
+      # DEL becomes UNLINK if lazyfree-lazy-user-del is set
+      # https://github.com/redis/redis/pull/6243
+      # https://redis.io/docs/management/config-file/
+      if doc.name == "DEL" && config_get("lazyfree-lazy-user-del", redis:) == "yes"
+        doc = SaferRedis::CommandDoc.new("UNLINK")
+      end
+
+      if doc.dangerous?
+        # Anything tagged @dangerous is… dangerous
+        raise SaferRedis::Danger.new(doc)
+
+      elsif doc.slow? && doc.complexity != "O(1)"
+        # Anything tagged @slow might be dangerous, but we'll let through O(1)
+        # complexity commands e.g. SET
+        raise SaferRedis::Danger.new(doc)
+      end
+    end
+
+    def self.config_get(option, redis:)
+      SaferRedis.really { redis.config(:get, option)[option] }
+    end
+  end
+end

--- a/lib/safer_redis/interceptor.rb
+++ b/lib/safer_redis/interceptor.rb
@@ -4,7 +4,10 @@ module SaferRedis
   module Interceptor
     def send_command(command, &block)
       if SaferRedis.active?
-        SaferRedis.assess!(SaferRedis::CommandDoc.from_command_array(command))
+        SaferRedis::Assessor.assess!(
+          SaferRedis::CommandDoc.from_command_array(command),
+          redis: self,
+        )
       end
 
       super

--- a/lib/safer_redis/suggestion.rb
+++ b/lib/safer_redis/suggestion.rb
@@ -12,7 +12,10 @@ module SaferRedis
     def self.for_command(command)
       case command
       when "DEL"
-        new(command, "Consider using the non-blocking UNLINK command instead to delete the key on a background thread")
+        new(command, <<~END)
+          Consider using the non-blocking UNLINK command instead to delete the key on a \
+          background thread, or set the lazyfree-lazy-user-del server option
+        END
       else
         nil
       end

--- a/safer_redis.gemspec
+++ b/safer_redis.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "SaferRedis warns you before letting through commands that could impact production availability by being marked `@slow` or `@dangerous` in the Redis documentation"
   spec.homepage = "https://github.com/buildkite/safer_redis"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/buildkite/safer_redis"

--- a/spec/assessor_spec.rb
+++ b/spec/assessor_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe SaferRedis::Assessor do
+  let(:redis) { instance_double(Redis) }
+
+  describe ".assess!" do
+    context "without lazyfree-lazy-user-del" do
+      before do
+        expect(redis).to receive(:config).with(:get, "lazyfree-lazy-user-del") do
+          {"lazyfree-lazy-user-del" => "no"}
+        end
+      end
+
+      it "raises Danger for DEL because it's @slow" do
+        expect {
+          SaferRedis::Assessor.assess!(SaferRedis::CommandDoc.new("DEL"), redis:)
+        }.to raise_error(SaferRedis::Danger, <<~MESSAGE)
+        The DEL Redis command might be dangerous.
+
+        https://redis.io/commands/del/
+
+        ACL categories: @keyspace @write @slow
+
+        Complexity: O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).
+
+        If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
+
+        Suggestion: Consider using the non-blocking UNLINK command instead to delete the key on a background thread, or set the lazyfree-lazy-user-del server option
+
+        MESSAGE
+      end
+    end
+
+    context "with lazyfree-lazy-user-del" do
+      before do
+        expect(redis).to receive(:config).with(:get, "lazyfree-lazy-user-del") do
+          {"lazyfree-lazy-user-del" => "yes"}
+        end
+      end
+
+      it "allows DEL because it's acting as UNLINK" do
+        expect {
+          SaferRedis::Assessor.assess!(SaferRedis::CommandDoc.new("DEL"), redis:)
+        }.to_not raise_error
+      end
+    end
+
+    it "raises Danger for KEYS because it's @dangerous and @slow" do
+      expect {
+        SaferRedis::Assessor.assess!(SaferRedis::CommandDoc.new("KEYS"), redis:)
+      }.to raise_error(SaferRedis::Danger, <<~MESSAGE)
+        The KEYS Redis command might be dangerous.
+
+        https://redis.io/commands/keys/
+
+        ACL categories: @keyspace @read @slow @dangerous
+
+        Complexity: O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.
+
+        If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
+      MESSAGE
+    end
+
+    it "raises no error for TYPE because it's neither slow nor dangerous" do
+      expect {
+        SaferRedis::Assessor.assess!(SaferRedis::CommandDoc.new("TYPE"), redis:)
+      }.to_not raise_error
+    end
+
+    it "raises no error for SET because despite being @slow it's only O(1)" do
+      expect {
+        SaferRedis::Assessor.assess!(SaferRedis::CommandDoc.new("SET"), redis:)
+      }.to_not raise_error
+    end
+  end
+end

--- a/spec/safer_redis_spec.rb
+++ b/spec/safer_redis_spec.rb
@@ -1,54 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe SaferRedis do
-  describe ".assess!" do
-    it "raises Danger for DEL because it's @slow" do
-      expect {
-        SaferRedis.assess!(SaferRedis::CommandDoc.new("DEL"))
-      }.to raise_error(SaferRedis::Danger, <<~MESSAGE)
-        The DEL Redis command might be dangerous.
-
-        https://redis.io/commands/del/
-
-        ACL categories: @keyspace @write @slow
-
-        Complexity: O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).
-
-        If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
-
-        Suggestion: Consider using the non-blocking UNLINK command instead to delete the key on a background thread
-      MESSAGE
-    end
-
-    it "raises Danger for KEYS because it's @dangerous and @slow" do
-      expect {
-        SaferRedis.assess!(SaferRedis::CommandDoc.new("KEYS"))
-      }.to raise_error(SaferRedis::Danger, <<~MESSAGE)
-        The KEYS Redis command might be dangerous.
-
-        https://redis.io/commands/keys/
-
-        ACL categories: @keyspace @read @slow @dangerous
-
-        Complexity: O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.
-
-        If you're sure this is okay, you can try again within `SaferRedis.really { ... }`
-      MESSAGE
-    end
-
-    it "raises no error for TYPE because it's neither slow nor dangerous" do
-      expect {
-        SaferRedis.assess!(SaferRedis::CommandDoc.new("TYPE"))
-      }.to_not raise_error
-    end
-
-    it "raises no error for SET because despite being @slow it's only O(1)" do
-      expect {
-        SaferRedis.assess!(SaferRedis::CommandDoc.new("SET"))
-      }.to_not raise_error
-    end
-  end
-
   it "has a version number" do
     expect(SaferRedis::VERSION).not_to be nil
   end

--- a/spec/suggestion_spec.rb
+++ b/spec/suggestion_spec.rb
@@ -3,7 +3,10 @@ RSpec.describe SaferRedis::Suggestion do
     it "has a suggestion for DEL" do
       suggestion = SaferRedis::Suggestion.for_command("DEL")
 
-      expect(suggestion.description).to eq "Consider using the non-blocking UNLINK command instead to delete the key on a background thread"
+      expect(suggestion.description).to eq <<~END
+      Consider using the non-blocking UNLINK command instead to delete the key on a background \
+      thread, or set the lazyfree-lazy-user-del server option
+      END
     end
 
     it "has no suggestion for KEYS" do


### PR DESCRIPTION
Treat the [`DEL`](https://redis.io/commands/del/) command as [`UNLINK`](https://redis.io/commands/unlink/) when the `lazyfree-lazy-user-del` server option is enabled.

See #5 for more context.

This required some refactoring so that the assessor could issue the Redis command `CONFIG GET lazyfree-lazy-user-del`; we now have a separate `SaferRedis::Assessor` class and pass the Redis client to its `.assess!` method.

We're now using Ruby 3.2 implicit hash values (`redis:`), so earlier Rubies won't work. If that breaks something for somebody, I'd be happy to switch to the old (`redis: redis`) non-implicit style.


Related:
- Closes #5
- https://redis.io/docs/management/config-file/
- redis/redis#6243